### PR TITLE
Add a docker based environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+/data/**/*.jpg
+/data/**/*.JPG

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 /data/**/*.jpg
 /data/**/*.JPG
+/docker/Dockerfile

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,17 +1,19 @@
 FROM python:3.8
 
-RUN apt-get update \
-  && apt-get -y install graphviz \
+RUN apt-get update -qq \
+  && apt-get -y install graphviz python3-opencv \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
-COPY . .
-COPY ./docker/entrypoint.sh /entrypoint.sh
+COPY ./docker/requirements.txt /app/docker/requirements.txt
 
 RUN pip3 install --upgrade --no-cache-dir --no-binary \
     Cython==0.29.21 \
     numpy==1.19.2 \
   && pip3 install -r /app/docker/requirements.txt
 
+COPY . .
+
+COPY ./docker/entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["jupyter", "notebook", "--allow-root", "--ip=0.0.0.0", "--port=8888"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,14 +1,17 @@
-FROM python:3
-
-WORKDIR /app
-COPY . .
-COPY ./docker/entrypoint.sh /entrypoint.sh
+FROM python:3.8
 
 RUN apt-get update \
   && apt-get -y install graphviz \
   && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install -r /app/requirements.txt
+WORKDIR /app
+COPY . .
+COPY ./docker/entrypoint.sh /entrypoint.sh
+
+RUN pip3 install --upgrade --no-cache-dir --no-binary \
+    Cython==0.29.21 \
+    numpy==1.19.2 \
+  && pip3 install -r /app/docker/requirements.txt
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["jupyter", "notebook", "--allow-root", "--ip=0.0.0.0", "--port=8888"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3
+
+WORKDIR /app
+COPY . .
+COPY ./docker/entrypoint.sh /entrypoint.sh
+
+RUN apt-get update \
+  && apt-get -y install graphviz \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install -r /app/requirements.txt
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["jupyter", "notebook", "--allow-root", "--ip=0.0.0.0", "--port=8888"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,4 +2,4 @@
 
 python /app/download.py
 
-exec $@
+exec "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+python /app/download.py
+
+exec $@

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,0 +1,14 @@
+pillow
+requests
+jupyter
+numpy
+pandas
+matplotlib
+seaborn
+graphviz
+Cython
+tensorflow==2.4.1
+scikit-image
+pycocotools
+keras
+imgaug

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -12,3 +12,5 @@ scikit-image
 pycocotools
 keras
 imgaug
+
+nbstripout==0.3.8


### PR DESCRIPTION
This pull request adds the infrastructure for running TACO within a docker container.

An additional requirements file is provided in `docker/` as the current requirement file adds windows deps and I can't be fucked to make that platform specific.

Creating the appropriate docker image and running jupyter can be accomplished by running `make build run`. The notebook can be validated for correctness by running `make test`.

Makefile help documentation:

```
❯ make help
help                           Prints help for targets with comments
jupyter                        Launch Jupyter notebook, bound to port 8888 on the host system
test                           Test the detector notebook
shell                          Run a new container and execute bash
build                          Build the detritus container
nbstripout                     Strip output from all Jupyter notebooks
```